### PR TITLE
tomcat 8 prep

### DIFF
--- a/cookbooks/imos_webapps/recipes/generic_webapp.rb
+++ b/cookbooks/imos_webapps/recipes/generic_webapp.rb
@@ -38,7 +38,7 @@ if node['webapps'] && node['webapps']['instances']
     instance_aliases           = instance['aliases']
     instance_tomcat_port       = instance['port']
     instance_base_directory    = "#{node['tomcat']['base']}/#{instance_name}"
-    instance_service_name      = "tomcat#{node["tomcat"]["version"]}_#{instance_name}"
+    instance_service_name      = "tomcat_#{instance_name}"
     instance_data_directory    = instance_parameters['data_dir'] || "#{instance_base_directory}/data/#{instance_name}"
     instance_apps              = instance['apps']
     instance_httpd_rules       = instance['httpd_rules']

--- a/cookbooks/tomcat/attributes/default.rb
+++ b/cookbooks/tomcat/attributes/default.rb
@@ -28,17 +28,13 @@ default["tomcat"]["log_level"] = "SEVERE"
 
 default["tomcat"]["pkg_url"] = "https://archive.apache.org/dist/tomcat/tomcat-7/v7.0.61/bin/apache-tomcat-7.0.61.tar.gz"
 default["tomcat"]["pkg_checksum"] = "2528ad7434e44ab1198b5692d5f831ac605051129119fd81a00d4c75abe1c0e0"
+#default["tomcat"]["pkg_url"] = "https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.tar.gz"
+#default["tomcat"]["pkg_checksum"] = "7e23260f2481aca88f89838e91cb9ff00548a28ba5a19a88ff99388c7ee9a9b8"
 
-default["tomcat"]["user"] = "tomcat#{tomcat["version"]}"
-default["tomcat"]["group"] = "tomcat#{tomcat["version"]}"
-default["tomcat"]["home"] = "/usr/share/tomcat#{tomcat["version"]}"
-default["tomcat"]["base"] = "/var/lib/tomcat#{tomcat["version"]}"
-default["tomcat"]["config_dir"] = "/etc/tomcat#{tomcat["version"]}"
-default["tomcat"]["log_dir"] = "/var/log/tomcat#{tomcat["version"]}"
-default["tomcat"]["tmp_dir"] = "/tmp/tomcat#{tomcat["version"]}-tmp"
-default["tomcat"]["work_dir"] = "/var/cache/tomcat#{tomcat["version"]}"
-default["tomcat"]["context_dir"] = "#{tomcat["config_dir"]}/Catalina/localhost"
-default["tomcat"]["webapp_dir"] = "/var/lib/tomcat#{tomcat["version"]}/webapps"
+default["tomcat"]["user"] = "tomcat7"
+default["tomcat"]["group"] = "tomcat7"
+default["tomcat"]["home"] = "/usr/share/tomcat7"
+default["tomcat"]["base"] = "/var/lib/tomcat7"
 
 # Max threads will be set to number of cores times 4 - that should be enough!
 # Tomcat original default is 200

--- a/cookbooks/tomcat/definitions/delete_tomcat_instance.rb
+++ b/cookbooks/tomcat/definitions/delete_tomcat_instance.rb
@@ -1,15 +1,14 @@
 define :delete_tomcat_instance do
   instance_name  = @params[:name]
-  tomcat_version = node['tomcat']['version']
 
   # Stop
-  service "tomcat#{tomcat_version}_#{instance_name}" do
-    service_name "tomcat#{tomcat_version}_#{instance_name}"
+  service "tomcat_#{instance_name}" do
+    service_name "tomcat_#{instance_name}"
     action [:stop, :disable]
   end
 
   # Delete init.d scripts.
-  file "/etc/init.d/tomcat#{tomcat_version}_#{instance_name}" do
+  file "/etc/init.d/tomcat_#{instance_name}" do
     action :delete
   end
 

--- a/cookbooks/tomcat/definitions/tomcat_instance.rb
+++ b/cookbooks/tomcat/definitions/tomcat_instance.rb
@@ -12,7 +12,7 @@ define :tomcat_instance do
   tomcat_fine_version = node['tomcat']['fine_version']
   instance_dir        = "#{node['tomcat']['base']}/#{name}"
   server_xml          = ::File.join(instance_dir, 'conf', 'server.xml')
-  init_d_service      = "tomcat#{tomcat_version}_#{name}"
+  init_d_service      = "tomcat_#{name}"
   init_d_service_path = ::File.join('etc', 'init.d', init_d_service)
   logging_properties  = ::File.join(instance_dir, 'conf', 'logging.properties')
   version_sh          = ::File.join(instance_dir, "bin", "version.sh")
@@ -67,7 +67,7 @@ define :tomcat_instance do
   # Create init.d script for each instance.
   template init_d_service_path do
     cookbook "tomcat"
-    source   "tomcat#{tomcat_version}.erb"
+    source   "tomcat.erb"
     owner    "root"
     group    "root"
     mode     00755

--- a/cookbooks/tomcat/recipes/default.rb
+++ b/cookbooks/tomcat/recipes/default.rb
@@ -9,8 +9,6 @@
 
 include_recipe "imos_java"
 
-tomcat_version = node['tomcat']['version']
-
 # Create user
 user node['tomcat']['user'] do
   system true
@@ -19,7 +17,11 @@ end
 # Create CATALINA_HOME
 directory node['tomcat']['home'] do
   owner     node['tomcat']['user']
-  group     node['tomcat']['user']
+  group     node['tomcat']['group']
   recursive true
   mode      00755
+end
+
+execute "remove tomcat7_ init.d" do
+  command "rm -f /etc/init.d/tomcat7_*"
 end

--- a/cookbooks/tomcat/templates/default/server_tomcat8.xml.erb
+++ b/cookbooks/tomcat/templates/default/server_tomcat8.xml.erb
@@ -1,0 +1,153 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- Note:  A "Server" is not itself a "Container", so you may not
+     define subcomponents such as "Valves" at this level.
+     Documentation at /docs/config/server.html
+ -->
+<Server port="<%= @ports[:port] %>" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <!-- Security listener. Documentation at /docs/config/listeners.html
+  <Listener className="org.apache.catalina.security.SecurityListener" />
+  -->
+  <!--APR library loader. Documentation at /docs/apr.html -->
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <!-- Global JNDI resources
+       Documentation at /docs/jndi-resources-howto.html
+  -->
+  <GlobalNamingResources>
+    <!-- Editable user database that can also be used by
+         UserDatabaseRealm to authenticate users
+    -->
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <!-- A "Service" is a collection of one or more "Connectors" that share
+       a single "Container" Note:  A "Service" is not itself a "Container",
+       so you may not define subcomponents such as "Valves" at this level.
+       Documentation at /docs/config/service.html
+   -->
+  <Service name="Catalina">
+
+    <!--The connectors can use a shared executor, you can define one or more named thread pools-->
+    <!--
+    <Executor name="tomcatThreadPool" namePrefix="catalina-exec-"
+        maxThreads="150" minSpareThreads="4"/>
+    -->
+
+
+    <!-- A "Connector" represents an endpoint by which requests are received
+         and responses are returned. Documentation at :
+         Java HTTP Connector: /docs/config/http.html (blocking & non-blocking)
+         Java AJP  Connector: /docs/config/ajp.html
+         APR (HTTP/AJP) Connector: /docs/apr.html
+         Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
+    -->
+    <Connector port="<%= @ports[:connector_port] %>" protocol="HTTP/1.1"
+<% if @instance['thread_control'] %>
+               maxThreads="<%= @instance['max_threads'] || node['tomcat']['max_threads'] %>"
+<% end %>
+               connectionTimeout="20000"
+               maxPostSize="<%= @instance['max_post_size'] || node['tomcat']['max_post_size'] %>"
+               URIEncoding="UTF-8"
+               redirectPort="<%= @ports[:redirect_port] %>" />
+    <!-- A "Connector" using the shared thread pool-->
+    <!--
+    <Connector executor="tomcatThreadPool"
+               port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443" />
+    -->
+    <!-- Define a SSL/TLS HTTP/1.1 Connector on port 8443
+         This connector uses the NIO implementation that requires the JSSE
+         style configuration. When using the APR/native implementation, the
+         OpenSSL style configuration is required as described in the APR/native
+         documentation -->
+    <!--
+    <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
+               maxThreads="150" SSLEnabled="true" scheme="https" secure="true"
+               clientAuth="false" sslProtocol="TLS" />
+    -->
+
+    <!-- Define an AJP 1.3 Connector on port 8009 -->
+    <!--
+    <Connector port="<%= @ports[:ajp_port] %>" protocol="AJP/1.3" redirectPort="<%= @ports[:redirect_port] %>" />
+    -->
+
+    <!-- An Engine represents the entry point (within Catalina) that processes
+         every request.  The Engine implementation for Tomcat stand alone
+         analyzes the HTTP headers included with the request, and passes them
+         on to the appropriate Host (virtual host).
+         Documentation at /docs/config/engine.html -->
+
+    <!-- You should set jvmRoute to support load-balancing via AJP ie :
+    <Engine name="Catalina" defaultHost="localhost" jvmRoute="jvm1">
+    -->
+    <Engine name="Catalina" defaultHost="localhost">
+
+      <!--For clustering, please take a look at documentation at:
+          /docs/cluster-howto.html  (simple how to)
+          /docs/config/cluster.html (reference documentation) -->
+      <!--
+      <Cluster className="org.apache.catalina.ha.tcp.SimpleTcpCluster"/>
+      -->
+
+      <!-- Use the LockOutRealm to prevent attempts to guess user passwords
+           via a brute-force attack -->
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <!-- This Realm uses the UserDatabase configured in the global JNDI
+             resources under the key "UserDatabase".  Any edits
+             that are performed against this UserDatabase are immediately
+             available for use by the Realm.  -->
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost"  appBase="webapps"
+<% if @parallel_deploy %>
+            unpackWARs="true" autoDeploy="true" undeployOldVersions="true">
+<% else %>
+            unpackWARs="true" autoDeploy="false">
+<% end %>
+
+        <!-- SingleSignOn valve, share authentication between web applications
+             Documentation at: /docs/config/valve.html -->
+        <!--
+        <Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+        -->
+
+        <!-- Access log processes all example.
+             Documentation at: /docs/config/valve.html
+             Note: The pattern used is equivalent to using pattern="common" -->
+        <!--
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+        -->
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/cookbooks/tomcat/templates/default/tomcat.erb
+++ b/cookbooks/tomcat/templates/default/tomcat.erb
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# /etc/init.d/tomcat7 -- startup script for the tomcat7
+# /etc/init.d/tomcat -- startup script for the tomcat
 #
 # Written by Miquel van Smoorenburg <miquels@cistron.nl>.
 # Modified for Debian GNU/Linux	by Ian Murdock <imurdock@gnu.ai.mit.edu>.
@@ -10,7 +10,7 @@
 # Additional improvements by Jason Brittain <jason.brittain@mulesoft.com>.
 #
 ### BEGIN INIT INFO
-# Provides:          tomcat7
+# Provides:          tomcat
 # Required-Start:    $local_fs $remote_fs $network
 # Required-Stop:     $local_fs $remote_fs $network
 # Should-Start:      $named
@@ -26,7 +26,7 @@ set -e
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 NAME=<%= @name %>
 DESC="Tomcat servlet engine"
-DEFAULT=/etc/default/tomcat7/$NAME
+DEFAULT=/etc/default/tomcat/$NAME
 
 if [ `id -u` -ne 0 ]; then
 	echo "You need root privileges to run this script"
@@ -103,7 +103,7 @@ if [ -z "$CATALINA_TMPDIR" ]; then
 	CATALINA_TMPDIR="$JVM_TMP"
 fi
 
-# Set the JSP compiler if set in the tomcat7.default file
+# Set the JSP compiler if set in the tomcat.default file
 if [ -n "$JSP_COMPILER" ]; then
 	JAVA_OPTS="$JAVA_OPTS -Dbuild.compiler=\"$JSP_COMPILER\""
 fi
@@ -180,7 +180,7 @@ case "$1" in
 
 		# Regenerate POLICY_CACHE file
 		umask 022
-		echo "// AUTO-GENERATED FILE from /etc/tomcat7/policy.d/" \
+		echo "// AUTO-GENERATED FILE from /etc/tomcat/policy.d/" \
 			> "$POLICY_CACHE"
 		echo ""  >> "$POLICY_CACHE"
                 if [ -d $CATALINA_BASE/conf/policy.d ] ; then

--- a/cookbooks/tomcat/templates/default/tomcat.erb
+++ b/cookbooks/tomcat/templates/default/tomcat.erb
@@ -3,7 +3,7 @@
 # /etc/init.d/tomcat -- startup script for the tomcat
 #
 # Written by Miquel van Smoorenburg <miquels@cistron.nl>.
-# Modified for Debian GNU/Linux	by Ian Murdock <imurdock@gnu.ai.mit.edu>.
+# Modified for Debian GNU/Linux by Ian Murdock <imurdock@gnu.ai.mit.edu>.
 # Modified for Tomcat by Stefan Gybas <sgybas@debian.org>.
 # Modified for Tomcat6 by Thierry Carrez <thierry.carrez@ubuntu.com>.
 # Modified for Tomcat7 by Ernesto Hernandez-Novich <emhn@itverx.com.ve>.
@@ -29,20 +29,20 @@ DESC="Tomcat servlet engine"
 DEFAULT=/etc/default/tomcat/$NAME
 
 if [ `id -u` -ne 0 ]; then
-	echo "You need root privileges to run this script"
-	exit 1
+    echo "You need root privileges to run this script"
+    exit 1
 fi
 
 # Make sure tomcat is started with system locale
 if [ -r /etc/default/locale ]; then
-	. /etc/default/locale
-	export LANG
+    . /etc/default/locale
+    export LANG
 fi
 
 . /lib/lsb/init-functions
 
 if [ -r /etc/default/rcS ]; then
-	. /etc/default/rcS
+    . /etc/default/rcS
 fi
 
 
@@ -59,7 +59,7 @@ JDK_DIRS="/usr/lib/jvm/default-java /usr/lib/jvm/java-<%= node['java']['jdk_vers
 # Look for the right JVM to use
 for jdir in $JDK_DIRS; do
     if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
-	JAVA_HOME="$jdir"
+        JAVA_HOME="$jdir"
     fi
 done
 export JAVA_HOME
@@ -82,35 +82,35 @@ TOMCAT7_SECURITY=no
 # It also looks like the default heap size of 64M is not enough for most cases
 # so the maximum heap size is set to 128M
 if [ -z "$JAVA_OPTS" ]; then
-	JAVA_OPTS="<%= @java_opts %>"
+    JAVA_OPTS="<%= @java_opts %>"
 fi
 
 # End of variables that can be overwritten in $DEFAULT
 
 # overwrite settings from default file
 if [ -f "$DEFAULT" ]; then
-	. "$DEFAULT"
+    . "$DEFAULT"
 fi
 
 if [ ! -f "$CATALINA_HOME/bin/bootstrap.jar" ]; then
-	log_failure_msg "$NAME is not installed"
-	exit 1
+    log_failure_msg "$NAME is not installed"
+    exit 1
 fi
 
 POLICY_CACHE="$CATALINA_BASE/work/catalina.policy"
 
 if [ -z "$CATALINA_TMPDIR" ]; then
-	CATALINA_TMPDIR="$JVM_TMP"
+    CATALINA_TMPDIR="$JVM_TMP"
 fi
 
 # Set the JSP compiler if set in the tomcat.default file
 if [ -n "$JSP_COMPILER" ]; then
-	JAVA_OPTS="$JAVA_OPTS -Dbuild.compiler=\"$JSP_COMPILER\""
+    JAVA_OPTS="$JAVA_OPTS -Dbuild.compiler=\"$JSP_COMPILER\""
 fi
 
 SECURITY=""
 if [ "$TOMCAT7_SECURITY" = "yes" ]; then
-	SECURITY="-security"
+    SECURITY="-security"
 fi
 
 # Define other required variables
@@ -123,156 +123,160 @@ if [ -z "${JSSE_HOME}" -a -r "${JAVA_HOME}/jre/lib/jsse.jar" ]; then
 fi
 
 catalina_sh() {
-	# Escape any double quotes in the value of JAVA_OPTS
-	JAVA_OPTS="$(echo $JAVA_OPTS | sed 's/\"/\\\"/g')"
+    # Escape any double quotes in the value of JAVA_OPTS
+    JAVA_OPTS="$(echo $JAVA_OPTS | sed 's/\"/\\\"/g')"
 
-	AUTHBIND_COMMAND=""
-	if [ "$AUTHBIND" = "yes" -a "$1" = "start" ]; then
-		JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
-		AUTHBIND_COMMAND="/usr/bin/authbind --deep /bin/bash -c "
-	fi
+    AUTHBIND_COMMAND=""
+    if [ "$AUTHBIND" = "yes" -a "$1" = "start" ]; then
+        JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
+        AUTHBIND_COMMAND="/usr/bin/authbind --deep /bin/bash -c "
+    fi
 
-	# Define the command to run Tomcat's catalina.sh as a daemon
-	# set -a tells sh to export assigned variables to spawned shells.
-	TOMCAT_SH="set -a; JAVA_HOME=\"$JAVA_HOME\"; source \"$DEFAULT\"; \
-		CATALINA_HOME=\"$CATALINA_HOME\"; \
-		CATALINA_BASE=\"$CATALINA_BASE\"; \
-		JAVA_OPTS=\"$JAVA_OPTS\"; \
-		CATALINA_PID=\"$CATALINA_PID\"; \
-		CATALINA_TMPDIR=\"$CATALINA_TMPDIR\"; \
-		LANG=\"$LANG\"; JSSE_HOME=\"$JSSE_HOME\"; \
-		cd \"$CATALINA_BASE\"; \
-		\"$CATALINA_SH\" $@"
+    # Define the command to run Tomcat's catalina.sh as a daemon
+    # set -a tells sh to export assigned variables to spawned shells.
+    TOMCAT_SH="set -a; JAVA_HOME=\"$JAVA_HOME\"; source \"$DEFAULT\"; \
+        CATALINA_HOME=\"$CATALINA_HOME\"; \
+        CATALINA_BASE=\"$CATALINA_BASE\"; \
+        JAVA_OPTS=\"$JAVA_OPTS\"; \
+        CATALINA_PID=\"$CATALINA_PID\"; \
+        CATALINA_TMPDIR=\"$CATALINA_TMPDIR\"; \
+        LANG=\"$LANG\"; JSSE_HOME=\"$JSSE_HOME\"; \
+        cd \"$CATALINA_BASE\"; \
+        \"$CATALINA_SH\" $@"
 
 
-	if [ "$AUTHBIND" = "yes" -a "$1" = "start" ]; then
-		TOMCAT_SH="'$TOMCAT_SH'"
-	fi
+    if [ "$AUTHBIND" = "yes" -a "$1" = "start" ]; then
+        TOMCAT_SH="'$TOMCAT_SH'"
+    fi
 
-	# Run the catalina.sh script as a daemon
-	set +e
-	touch "$CATALINA_PID" "$CATALINA_BASE"/logs/catalina.out
-	chown $TOMCAT_USER "$CATALINA_PID" "$CATALINA_BASE"/logs/catalina.out
-	start-stop-daemon --start -b -u "$TOMCAT_USER" -g "$TOMCAT_GROUP" \
-		-c "$TOMCAT_USER" -d "$CATALINA_TMPDIR" -p "$CATALINA_PID" \
-		-x /bin/bash -- -c "$AUTHBIND_COMMAND $TOMCAT_SH"
-	status="$?"
-	set +a -e
-	return $status
+    # Run the catalina.sh script as a daemon
+    set +e
+    touch "$CATALINA_PID" "$CATALINA_BASE"/logs/catalina.out
+    chown $TOMCAT_USER "$CATALINA_PID" "$CATALINA_BASE"/logs/catalina.out
+    start-stop-daemon --start -b -u "$TOMCAT_USER" -g "$TOMCAT_GROUP" \
+        -c "$TOMCAT_USER" -d "$CATALINA_TMPDIR" -p "$CATALINA_PID" \
+        -x /bin/bash -- -c "$AUTHBIND_COMMAND $TOMCAT_SH"
+    status="$?"
+    set +a -e
+    return $status
 }
 
 case "$1" in
-  start)
-	if [ -z "$JAVA_HOME" ]; then
-		log_failure_msg "no JDK found - please set JAVA_HOME"
-		exit 1
-	fi
+    start)
+        if [ -z "$JAVA_HOME" ]; then
+            log_failure_msg "no JDK found - please set JAVA_HOME"
+            exit 1
+        fi
 
-	if [ ! -d "$CATALINA_BASE/conf" ]; then
-		log_failure_msg "invalid CATALINA_BASE: $CATALINA_BASE"
-		exit 1
-	fi
+        if [ ! -d "$CATALINA_BASE/conf" ]; then
+            log_failure_msg "invalid CATALINA_BASE: $CATALINA_BASE"
+            exit 1
+        fi
 
-	log_daemon_msg "Starting $DESC" "$NAME"
-	if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
-		--user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
-		>/dev/null; then
-
-		# Regenerate POLICY_CACHE file
-		umask 022
-		echo "// AUTO-GENERATED FILE from /etc/tomcat/policy.d/" \
-			> "$POLICY_CACHE"
-		echo ""  >> "$POLICY_CACHE"
-                if [ -d $CATALINA_BASE/conf/policy.d ] ; then
-		    cat $CATALINA_BASE/conf/policy.d/*.policy \
-			>> "$POLICY_CACHE"
-                fi
-
-		# Remove / recreate JVM_TMP directory
-		rm -rf "$JVM_TMP"
-		mkdir -p "$JVM_TMP" || {
-			log_failure_msg "could not create JVM temporary directory"
-			exit 1
-		}
-		chown $TOMCAT_USER "$JVM_TMP"
-
-		catalina_sh start $SECURITY
-		sleep 5
-        	if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
-			--user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
-			>/dev/null; then
-			if [ -f "$CATALINA_PID" ]; then
-				rm -f "$CATALINA_PID"
-			fi
-			log_end_msg 1
-		else
-			log_end_msg 0
-		fi
-	else
-	        log_progress_msg "(already running)"
-		log_end_msg 0
-	fi
-	;;
-  stop)
-	log_daemon_msg "Stopping $DESC" "$NAME"
-
-	set +e
-	if [ -f "$CATALINA_PID" ]; then
-		start-stop-daemon --stop --pidfile "$CATALINA_PID" \
-			--user "$TOMCAT_USER" \
-			--retry=TERM/20/KILL/5 >/dev/null
-		if [ $? -eq 1 ]; then
-			log_progress_msg "$DESC is not running but pid file exists, cleaning up"
-		elif [ $? -eq 3 ]; then
-			PID="`cat $CATALINA_PID`"
-			log_failure_msg "Failed to stop $NAME (pid $PID)"
-			exit 1
-		fi
-		rm -f "$CATALINA_PID"
-		rm -rf "$JVM_TMP"
-	else
-		log_progress_msg "(not running)"
-	fi
-	log_end_msg 0
-	set -e
-	;;
-   status)
-	set +e
-	start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
-		--user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
-		>/dev/null 2>&1
-	if [ "$?" = "0" ]; then
-
-		if [ -f "$CATALINA_PID" ]; then
-		    log_success_msg "$DESC is not running, but pid file exists."
-			exit 1
-		else
-		    log_success_msg "$DESC is not running."
-			exit 3
-		fi
-	else
-		log_success_msg "$DESC is running with pid `cat $CATALINA_PID`"
-	fi
-	set -e
-        ;;
-  restart|force-reload)
-	if [ -f "$CATALINA_PID" ]; then
-		$0 stop
-		sleep 1
-	fi
-	$0 start
-	;;
-  try-restart)
+        log_daemon_msg "Starting $DESC" "$NAME"
         if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
-		--user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
-		>/dev/null; then
-		$0 start
-	fi
-        ;;
-  *)
-	log_success_msg "Usage: $0 {start|stop|restart|try-restart|force-reload|status}"
-	exit 1
-	;;
+            --user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
+            >/dev/null; then
+
+            # Regenerate POLICY_CACHE file
+            umask 022
+            echo "// AUTO-GENERATED FILE from /etc/tomcat/policy.d/" \
+                > "$POLICY_CACHE"
+            echo ""  >> "$POLICY_CACHE"
+
+            if [ -d $CATALINA_BASE/conf/policy.d ] ; then
+                cat $CATALINA_BASE/conf/policy.d/*.policy \
+                    >> "$POLICY_CACHE"
+            fi
+
+            # Remove / recreate JVM_TMP directory
+            rm -rf "$JVM_TMP"
+            mkdir -p "$JVM_TMP" || {
+                log_failure_msg "could not create JVM temporary directory"
+                exit 1
+            }
+            chown $TOMCAT_USER "$JVM_TMP"
+
+            catalina_sh start $SECURITY
+            sleep 5
+
+            if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+                --user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
+                >/dev/null; then
+
+            if [ -f "$CATALINA_PID" ]; then
+                rm -f "$CATALINA_PID"
+            fi
+            log_end_msg 1
+        else
+            log_end_msg 0
+        fi
+    else
+        log_progress_msg "(already running)"
+        log_end_msg 0
+    fi
+    ;;
+    stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+
+        set +e
+        if [ -f "$CATALINA_PID" ]; then
+            start-stop-daemon --stop --pidfile "$CATALINA_PID" \
+                --user "$TOMCAT_USER" \
+                --retry=TERM/20/KILL/5 >/dev/null
+            if [ $? -eq 1 ]; then
+                log_progress_msg "$DESC is not running but pid file exists, cleaning up"
+            elif [ $? -eq 3 ]; then
+                PID="`cat $CATALINA_PID`"
+                log_failure_msg "Failed to stop $NAME (pid $PID)"
+                exit 1
+            fi
+            rm -f "$CATALINA_PID"
+            rm -rf "$JVM_TMP"
+        else
+            log_progress_msg "(not running)"
+        fi
+        log_end_msg 0
+        set -e
+    ;;
+    status)
+        set +e
+        start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+            --user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
+            >/dev/null 2>&1
+        if [ "$?" = "0" ]; then
+
+            if [ -f "$CATALINA_PID" ]; then
+                log_success_msg "$DESC is not running, but pid file exists."
+                exit 1
+            else
+                log_success_msg "$DESC is not running."
+                exit 3
+            fi
+        else
+            log_success_msg "$DESC is running with pid `cat $CATALINA_PID`"
+        fi
+        set -e
+    ;;
+    restart|force-reload)
+    if [ -f "$CATALINA_PID" ]; then
+        $0 stop
+        sleep 1
+    fi
+    $0 start
+    ;;
+    try-restart)
+        if start-stop-daemon --test --start --pidfile "$CATALINA_PID" \
+            --user $TOMCAT_USER --exec "$JAVA_HOME/bin/java" \
+            >/dev/null; then
+
+            $0 start
+        fi
+    ;;
+    *)
+        log_success_msg "Usage: $0 {start|stop|restart|try-restart|force-reload|status}"
+        exit 1
+    ;;
 esac
 
 exit 0


### PR DESCRIPTION
Still leaves us at tomcat7 and openjdk7 - however this is some preliminary work before we can embed the following in edge and systest, then in all:
```
    "tomcat": {
        "fine_version": "8.0.32",
        "pkg_url": "https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.32/bin/apache-tomcat-8.0.32.tar.gz",
        "pkg_checksum": "7e23260f2481aca88f89838e91cb9ff00548a28ba5a19a88ff99388c7ee9a9b8"
    },
    "java": {
        "jdk_version": 8
    },
```

The annoying part will come when we need to rename the `tomcat7` user to `tomcat` and `/mnt/ebs/tomcat7` to `/mnt/ebs/tomcat`. I think that doing that manually can be faster - or not manually, with a script - just not with chef. Renaming the user will require killing all the tomcat containers because otherwise Linux will prohibit us from doing that.

Something along the lines of this will probably solve the problem:
```
#!/bin/bash

# stop all tomcats
for tomcat in /etc/init.d/tomcat_*; do $tomcat stop; done

# move homedir (doesn't exist anyway :)
usermod -d /home/tomcat tomcat7

# rename user
usermod -l tomcat tomcat7

# rename group
groupmod -n tomcat tomcat7

# move tomcat home
mv /mnt/ebs/tomcat7 /mnt/ebs/tomcat

# fix init scripts - chef will do it anyway, but try to minimize downtime
for tomcat in /etc/init.d/tomcat_*; do sed -i -e 's/tomcat7/tomcat/g' $tomcat; done

# start tomcats again
for tomcat in /etc/init.d/tomcat_*; do $tomcat start; done
```