### PR TITLE
imos_vsftpd: Prevent mkdir

### DIFF
--- a/cookbooks/imos_vsftpd/templates/default/vsftpd.conf.erb
+++ b/cookbooks/imos_vsftpd/templates/default/vsftpd.conf.erb
@@ -53,3 +53,6 @@ pasv_enable=yes
 pasv_min_port=64000
 pasv_max_port=64100
 pasv_address=<%= node['network']['public_ipv4'] %>
+
+# Prevent users from creating new directories
+cmds_denied=MKD


### PR DESCRIPTION
Prevent users from creating new directories in the FTP hierarchy.
They must upload to existing, managed directories.