### PR TITLE
imos_po: Use credentials from data bags

### DIFF
--- a/cookbooks/imos_po/attributes/data_services.rb
+++ b/cookbooks/imos_po/attributes/data_services.rb
@@ -87,3 +87,6 @@ default['imos_po']['data_services']['celeryd']['inotify_config']    = ::File.joi
 default['imos_po']['data_services']['celeryd']['max_tasks']         = 1
 
 default['imos_po']['data_services']['create_watched_directories'] = false
+
+default['imos_po']['data_services']['credentials_pattern'] = "*"
+default['imos_po']['data_services']['credentials_prefix'] = "IMOS_PO_CREDS"

--- a/private-sample/data_bags/imos_po_credentials/aatams_ftp.json
+++ b/private-sample/data_bags/imos_po_credentials/aatams_ftp.json
@@ -1,0 +1,6 @@
+{
+    "id": "aatams_ftp",
+    "address": "smuc.st-and.ac.uk",
+    "username": "STUBBED",
+    "password": "STUBBED"
+}

--- a/private-sample/data_bags/imos_po_credentials/bom_ftp.json
+++ b/private-sample/data_bags/imos_po_credentials/bom_ftp.json
@@ -1,0 +1,6 @@
+{
+    "id": "bom_ftp",
+    "address": "ftp.bom.gov.au",
+    "username": "STUBBED",
+    "password": "STUBBED"
+}


### PR DESCRIPTION
Plant credentials in imos_po environment. Those credentials can
be driven by data bags, rather than hard coded in various
data-services scripts.