### PR TITLE
imos_po: Bulk async upload option

### DIFF
--- a/cookbooks/imos_po/attributes/data_services.rb
+++ b/cookbooks/imos_po/attributes/data_services.rb
@@ -90,3 +90,5 @@ default['imos_po']['data_services']['create_watched_directories'] = false
 
 default['imos_po']['data_services']['credentials_pattern'] = "*"
 default['imos_po']['data_services']['credentials_prefix'] = "IMOS_PO_CREDS"
+
+default['imos_po']['data_services']['async_upload']['max_tasks'] = 4

--- a/cookbooks/imos_po/libraries/watch_jobs.rb
+++ b/cookbooks/imos_po/libraries/watch_jobs.rb
@@ -26,4 +26,13 @@ class Chef::Recipe::WatchJobs
     return watchlists
   end
 
+  def self.get_s3cmd(node)
+    s3cmd = "s3cmd --config=#{node['imos_po']['s3']['config_file']}"
+    if Chef::Config[:dev]
+      s3cmd = "s3cmd-mocked"
+    end
+
+    return s3cmd
+  end
+
 end

--- a/cookbooks/imos_po/recipes/data_services.rb
+++ b/cookbooks/imos_po/recipes/data_services.rb
@@ -87,11 +87,6 @@ if node['talend']
   harvester_trigger_cmd = "sudo -u #{node['talend']['user']} #{node['talend']['trigger']['bin']} -c #{node['talend']['trigger']['config']}"
 end
 
-s3cmd = "s3cmd --config=#{node['imos_po']['s3']['config_file']}"
-if Chef::Config[:dev]
-  s3cmd = "s3cmd-mocked"
-end
-
 # Inject those variables to the cronjobs
 # Please note all variables here must be fully expanded to avoid scripts
 # needing to evaluate them at runtime
@@ -110,7 +105,7 @@ data_services_vars = {
   'DATA_SERVICES_DIR' => data_services_dir,
   'LOG_DIR'           => node['imos_po']['data_services']['log_dir'],
   'DATA_DIR'          => node['imos_po']['data_services']['data_dir'],
-  'S3CMD'             => s3cmd,
+  'S3CMD'             => Chef::Recipe::WatchJobs.get_s3cmd(node),
   'S3_BUCKET'         => node['imos_po']['s3']['bucket'],
   'MAILX_CONFIG'      => node['imos_po']['mailx']['config_file'],
   'HARVESTER_TRIGGER' => harvester_trigger_cmd

--- a/cookbooks/imos_po/recipes/watches.rb
+++ b/cookbooks/imos_po/recipes/watches.rb
@@ -38,6 +38,12 @@ template watch_exec_wrapper do
   })
 end
 
+template "/usr/local/bin/async-upload.py" do
+  owner 'root'
+  group 'root'
+  mode  0755
+end
+
 ruby_block "verify_watched_directories" do
   block do
     all_paths = []
@@ -134,6 +140,15 @@ if node['imos_po']['data_services']['watches']
 
   supervisor_service "inotify_po" do
     command    node['imos_po']['data_services']['celeryd']['inotify']
+    directory  node['imos_po']['data_services']['celeryd']['dir']
+    user       po_user
+    action     [:enable, :restart]
+    subscribes :restart, 'git[data_services]', :delayed
+  end
+
+  async_upload_max_tasks = node['imos_po']['data_services']['async_upload']['max_tasks']
+  supervisor_service "async_upload_po" do
+    command    "celeryd --queues=async_upload --config=#{celery_config} -A tasks -c #{async_upload_max_tasks}"
     directory  node['imos_po']['data_services']['celeryd']['dir']
     user       po_user
     action     [:enable, :restart]

--- a/cookbooks/imos_po/templates/default/async-upload.py.erb
+++ b/cookbooks/imos_po/templates/default/async-upload.py.erb
@@ -1,0 +1,9 @@
+#!/usr/bin/python
+
+import sys
+sys.path.insert(0, "<%= node['imos_po']['data_services']['celeryd']['dir'] %>")
+from tasks import *
+
+for line in sys.stdin:
+    src_file, dst_file = line.rstrip('\n').split(" ")
+    async_upload.delay(src_file, dst_file)

--- a/cookbooks/imos_po/templates/default/celeryconfig.py.erb
+++ b/cookbooks/imos_po/templates/default/celeryconfig.py.erb
@@ -25,5 +25,6 @@ celery_routes = {}
 @watchlists.each do |job_name, watchlist|
   celery_routes["tasks.#{job_name}"] = { "queue" => job_name }
 end
+celery_routes["tasks.async_upload"] = { "queue" => "async_upload" }
 %>
 CELERY_ROUTES = <%= celery_routes.to_json %>

--- a/cookbooks/imos_po/templates/default/tasks.py.erb
+++ b/cookbooks/imos_po/templates/default/tasks.py.erb
@@ -2,7 +2,7 @@
 
 from celery import Celery
 import subprocess
-from os import system
+from os import system, path
 
 app = Celery('tasks')
 app.config_from_object('<%= @celery_config.gsub(/.py$/, "") %>')
@@ -32,3 +32,22 @@ def <%= job_name %>(file_path):
 <%
   end
 end %>
+
+<%
+s3cmd_parts = Chef::Recipe::WatchJobs.get_s3cmd(node).split(" ")
+s3cmd_quoted = s3cmd_parts.map{ |s| "\"#{s}\""}.join(', ')
+%>
+@app.task(ignore_result=True)
+def async_upload(src_path, dst_path):
+    command = [
+        <%= s3cmd_quoted %>,
+        "sync",
+        "--no-preserve",
+        src_path,
+        path.join("<%= node['imos_po']['s3']['bucket'] %>", dst_path)
+    ]
+    print command
+    ret = subprocess.call(command)
+    if ret != 0:
+        raise Exception("ERROR uploading '%s' -> '%s'" % (src_path, dst_path))
+


### PR DESCRIPTION
Upload many files asynchronously by piping them to
`async-upload.py`.

Example usage for a single file:
```
$ echo "SRC DST" | async-upload.py
$ echo "/tmp/IMOS_ACORN_V_20100716T060000Z_BONC_FV00_sea-state.n IMOS/ACORN/vector/BONC/2010/07/16/IMOS_ACORN_V_20100716T060000Z_BONC_FV00_sea-state.nc" | async-upload.py
```

Uploading multiple files:
```
$ find . -type f | cut -c3- | awk -v pwd=$PWD '{print pwd"/"$1 " " "IMOS/"$1}'
/tmp/ABOS_SOFS/ff/d/e/file2 IMOS/d/e/file2
/tmp/ABOS_SOFS/ff/file3 IMOS/file3
/tmp/ABOS_SOFS/ff/a/b/c/file1 IMOS/a/b/c/file1

$ find . -type f | cut -c3- | awk -v pwd=$PWD '{print pwd"/"$1 " " "IMOS/"$1}' | async-upload.py
```