### PR TITLE
imos_po: Create watches on first provision

### DIFF
--- a/cookbooks/imos_po/recipes/watches.rb
+++ b/cookbooks/imos_po/recipes/watches.rb
@@ -94,7 +94,7 @@ if node['imos_po']['data_services']['watches']
     source     "tasks.py.erb"
     variables  ({
       :celery_config     => ::File.basename(celery_config),
-      :watchlists        => Chef::Recipe::WatchJobs.get_watches(data_services_watch_dir),
+      :watch_dir         => data_services_watch_dir,
       :data_services_dir => data_services_dir
     })
     subscribes :create, 'git[data_services]', :delayed
@@ -111,7 +111,7 @@ if node['imos_po']['data_services']['watches']
   template celery_config do
     source    "celeryconfig.py.erb"
     variables ({
-      :watchlists        => Chef::Recipe::WatchJobs.get_watches(data_services_watch_dir),
+      :watch_dir          => data_services_watch_dir,
       :password_data_bag => password_data_bag,
       :backend           => backend
     })
@@ -127,7 +127,7 @@ if node['imos_po']['data_services']['watches']
   template node['imos_po']['data_services']['celeryd']['inotify_config'] do
     source    "inotify-config.py.erb"
     variables ({
-      :watchlists => Chef::Recipe::WatchJobs.get_watches(data_services_watch_dir),
+      :watch_dir => data_services_watch_dir
     })
     subscribes :create, 'git[data_services]', :delayed
   end

--- a/cookbooks/imos_po/templates/default/celeryconfig.py.erb
+++ b/cookbooks/imos_po/templates/default/celeryconfig.py.erb
@@ -22,7 +22,8 @@ BROKER_TRANSPORT_OPTIONS = {
 # Create automatic routing for all queues, kindly stolen from:
 # http://stackoverflow.com/questions/9167663/celery-per-task-concurrency-limits-of-workers-per-task
 celery_routes = {}
-@watchlists.each do |job_name, watchlist|
+watchlists = Chef::Recipe::WatchJobs.get_watches(@watch_dir)
+watchlists.each do |job_name, watchlist|
   celery_routes["tasks.#{job_name}"] = { "queue" => job_name }
 end
 %>

--- a/cookbooks/imos_po/templates/default/inotify-config.py.erb
+++ b/cookbooks/imos_po/templates/default/inotify-config.py.erb
@@ -2,7 +2,8 @@ mask = pyinotify.IN_MOVED_TO | pyinotify.IN_CLOSE_WRITE
 
 watched_directories = {
 <%
-@watchlists.each do |job_name, watchlist|
+watchlists = Chef::Recipe::WatchJobs.get_watches(@watch_dir)
+watchlists.each do |job_name, watchlist|
   watchlist['path'].each do |path|
     path = ::File.join(node['imos_po']['data_services']['incoming_dir'], path)
 %>

--- a/cookbooks/imos_po/templates/default/tasks.py.erb
+++ b/cookbooks/imos_po/templates/default/tasks.py.erb
@@ -19,7 +19,8 @@ def watch_exec_wrapper(job_name, file_path, execute, execute_params):
     subprocess.call(command)
 
 <%
-@watchlists.each do |job_name, watchlist|
+watchlists = Chef::Recipe::WatchJobs.get_watches(@watch_dir)
+watchlists.each do |job_name, watchlist|
   watchlist['path'].each do |path|
     path = ::File.join(node['imos_po']['data_services']['incoming_dir'], path)
     execute = ::File.join(@data_services_dir, watchlist['execute'])


### PR DESCRIPTION
The problem this PR solves is described in #240.

The fix is rather awkward, but works properly. Any related
template would subscribe to be notified after git[data_services]
is updated, however it would evaluate the list of watches before
the git repository was updated as a template variables.
Eventually when the template is evaluated, it would use a stale
watch list which consists of watches *before* git[data_services]
was updated. The template however would be evaluated after
git[data_services] was updated.

The fix moved the evaluation of the watch list to the template
itself. This causes the list of watches to be evaluated *after*
git[data_services] was updated, thus resulting in the right list
of watches used by the template.

Fixes #240