### PR TITLE
imos_po: s3lsv - List versions of file on S3

### DIFF
--- a/cookbooks/imos_po/attributes/data_services.rb
+++ b/cookbooks/imos_po/attributes/data_services.rb
@@ -59,6 +59,7 @@ default['imos_po']['data_services']['packages'] = [
   'libnetcdf-dev',
   'mdbtools',
   'python-beautifulsoup',
+  'python-boto',
   'python-dev',
   'python-pip',
   'python-psycopg2',

--- a/cookbooks/imos_po/files/default/s3lsv
+++ b/cookbooks/imos_po/files/default/s3lsv
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import argparse
+import boto
+from boto.s3.prefix import Prefix
+
+def get_object_with_version(bucket, key, version, f):
+    k = bucket.get_key(key, version_id=version)
+    k.get_contents_to_filename(f)
+
+def list_object_versions(bucket, key):
+    for k in bucket.list_versions(key, delimiter='/'):
+        if type(k) is Prefix:
+            print k.name
+        else:
+            print "%s %s %s" % (k.version_id, k.last_modified, k.name)
+
+if __name__=='__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--anonymous", help="connect anonymously", action='store_true')
+    parser.add_argument("-b", "--bucket", help="bucket name to connect to", required=True)
+    parser.add_argument("-k", "--key", help="key (object name)", required=True)
+    parser.add_argument("-o", "--output", help="download object to file")
+    parser.add_argument("-v", "--version", help="together with '-o', specify version to download")
+
+    args = parser.parse_args()
+    
+    conn = boto.connect_s3(anon=args.anonymous)
+    bucket = conn.get_bucket(args.bucket)
+
+    if args.output and args.version:
+        get_object_with_version(bucket, args.key, args.version, args.output)
+    else:
+        list_object_versions(bucket, args.key)

--- a/cookbooks/imos_po/recipes/s3cmd.rb
+++ b/cookbooks/imos_po/recipes/s3cmd.rb
@@ -14,3 +14,7 @@ s3cmd_config node['imos_po']['s3']['config_file'] do
   access_key s3_data_bag['access_key_id']
   secret_key s3_data_bag['secret_access_key']
 end
+
+cookbook_file "/usr/local/bin/s3lsv" do
+  mode 00755
+end


### PR DESCRIPTION
Explore previous versions of objects using `s3lsv`.

Basic usage:
```
$ s3lsv
usage: s3-lsv.py [-h] [-a] -b BUCKET -k KEY [-o OUTPUT] [-v VERSION]
s3-lsv.py: error: argument -b/--bucket is required

$ s3lsv -a -b imos-data -k IMOS/
IMOS/AATAMS/
IMOS/ABOS/
...
IMOS/SRS/

$ s3lsv -a -b imos-data -k IMOS/ACORN/radial/TAN/2016/01/01/IMOS_ACORN_RV_20160101T235000Z_TAN_FV00_radial.nc
na5gI3LrPUyyfZ3JsHDFDV3WTAmFt2n5 2016-01-01T23:55:13.000Z IMOS/ACORN/radial/TAN/2016/01/01/IMOS_ACORN_RV_20160101T235000Z_TAN_FV00_radial.nc

$ s3lsv -a -b imos-data -k IMOS/ACORN/radial/TAN/2016/01/01/IMOS_ACORN_RV_20160101T235000Z_TAN_FV00_radial.nc -o /tmp/file.nc -v na5gI3LrPUyyfZ3JsHDFDV3WTAmFt2n5
$ ls -l /tmp/file.nc
-rw-rw-r-- 1 vagrant vagrant 263728 Jan  2 10:55 /tmp/file.nc
```