### PR TITLE
Chef changes for running Portal in root context

### DIFF
--- a/cookbooks/imos_apache2/templates/default/webapp.conf.erb
+++ b/cookbooks/imos_apache2/templates/default/webapp.conf.erb
@@ -1,7 +1,7 @@
 <%
 main_app_path = nil
-if @params[:apps] && @params[:apps].first
-  main_app_path = @params[:apps].first.keys.first
+if @params[:apps] && @params[:apps].any?  && !@params[:apps].detect {|p| p[:is_default_app] == 'true'}
+  main_app_path = @params[:apps].first[:name]
 end
 
 # Logs
@@ -57,7 +57,7 @@ end
 <%
 if @params[:cached]
   @params[:apps].each do |app|
-    app_name = app.keys.first
+    app_name = app[:name]
 %>
   ProxyRemote http://localhost:<%= @params[:app_port] %>/<%= app_name %> http://localhost:3128
 <%
@@ -89,9 +89,11 @@ end
 <%
 proxied_apps = []
 @params[:apps].each do |app|
-  app_name = app.keys.first
-  aliases  = app.values.first
-  proxied_apps << [ app_name, @params[:app_port], aliases ]
+
+  app_name = app[:name]
+  aliases  = app[:aliases]
+  is_default_app = app[:is_default_app] ? app[:is_default_app] : 'false'
+  proxied_apps << [ app_name, @params[:app_port], aliases, is_default_app ]
 end if @params[:apps]
 
 @params[:proxy_pass].each do |proxy_pair|
@@ -117,14 +119,19 @@ end if @params[:proxy_pass]
      app_name    = proxied_app[0]
      app_port    = proxied_app[1]
      app_aliases = proxied_app[2]
+     is_default_app = proxied_app[3]
+
+     # set URL paths to either / or /app_name depending on is_default_app flag
+     is_default_app == 'true' ? app_path = '' : app_path = "#{app_name}"
+
 %>
-  ProxyPass           /<%= app_name %> http://localhost:<%= app_port %>/<%= app_name %> retry=0
-  ProxyPassReverse    /<%= app_name %> http://localhost:<%= app_port %>/<%= app_name %>
+  ProxyPass           /<%= app_path %> http://localhost:<%= app_port %>/<%= app_path %> retry=0
+  ProxyPassReverse    /<%= app_path %> http://localhost:<%= app_port %>/<%= app_path %>
 
   # take care of extra aliases per app
   # forward all aliases to /name
 <%   app_aliases.each do |_alias| %>
-  RewriteRule ^/<%= _alias %>/*$ http://%{HTTP_HOST}/<%= app_name %>
+  RewriteRule ^/<%= _alias %>/*$ http://%{HTTP_HOST}/<%= app_path %>
 <%   end if app_aliases -%>
 <% end %>
 

--- a/cookbooks/imos_webapps/definitions/imos_tomcat_context.rb
+++ b/cookbooks/imos_webapps/definitions/imos_tomcat_context.rb
@@ -8,7 +8,6 @@ define :imos_tomcat_context do
   service_name        = @params[:service_name]
   config_dir          = File.join(base_directory, "conf", app_name)
   context_dir         = File.join(base_directory, "conf", "Catalina", "localhost")
-  context_file        = File.join(context_dir, "#{app_name}.xml")
   tomcat_webapps_dir = ::File.join(base_directory, "webapps")
 
   # Assume jenkins job is given if data bag is not available
@@ -18,6 +17,7 @@ define :imos_tomcat_context do
   # NOTE: this assumes that having a default app and parallel deployment are mutually
   # exclusive. The default app configuration will take precendence.
   is_default_app == 'true' ? app_deploy_name = 'ROOT' : app_deploy_name = app_name
+  context_file        = File.join(context_dir, "#{app_deploy_name}.xml")
 
   service_notify_action = :restart
 

--- a/cookbooks/imos_webapps/definitions/imos_tomcat_webapp.rb
+++ b/cookbooks/imos_webapps/definitions/imos_tomcat_webapp.rb
@@ -6,6 +6,7 @@
 
 define :imos_tomcat_webapp do
   application_name     = params[:application_name]
+  is_default_app       = params[:is_default_app]
   artifact_name        = params[:artifact_name]
   data_directories     = params[:data_directories]
   config_template_dir  = params[:config_template_dir]
@@ -47,6 +48,7 @@ define :imos_tomcat_webapp do
   # Install war & context xml into place
   imos_tomcat_context artifact_name do
     app_name             application_name
+    is_default_app       is_default_app
     tomcat_instance_name tomcat_instance_name
     service_name         service_name
     parallel_deploy      custom_parameters['parallel_deploy']
@@ -55,6 +57,7 @@ define :imos_tomcat_webapp do
     base_directory       base_directory
     template_variables   ({
       :custom_parameters     => custom_parameters,
+      :is_default_app        => is_default_app,
       :tomcat_instance_name  => tomcat_instance_name,
       :tomcat_base_directory => base_directory,
       :tomcat_data_directory => data_directory,

--- a/cookbooks/imos_webapps/recipes/generic_webapp.rb
+++ b/cookbooks/imos_webapps/recipes/generic_webapp.rb
@@ -34,6 +34,7 @@ if node['webapps'] && node['webapps']['instances']
 
     instance_parameters        = instance
     instance_name              = instance['name']
+    instance_default_app       = instance['default_app']
     instance_vhost             = instance['vhost']
     instance_aliases           = instance['aliases']
     instance_tomcat_port       = instance['port']
@@ -47,7 +48,7 @@ if node['webapps'] && node['webapps']['instances']
     # vhost aliases!!!)
     apps = []
     instance_apps.each do |app|
-      apps << { app['name'] => app['aliases'] }
+      apps << { :name => app['name'], :aliases => app['aliases'], :is_default_app => app['name'] == instance_default_app ? 'true' : 'false' }
     end
 
     # Make sure we don't have port duplicates
@@ -92,6 +93,7 @@ if node['webapps'] && node['webapps']['instances']
     # Build all the web apps
     instance_apps.each do |instance_app|
       app_name               = instance_app['name']
+      is_default_app         = instance_app['name'] == instance_default_app ? 'true' : 'false'
       backup                 = instance_app['backup']
       jndis                  = instance_app['jndis']
       artifact               = instance_app['artifact']
@@ -105,10 +107,14 @@ if node['webapps'] && node['webapps']['instances']
       app_parameters = instance_parameters.dup
       app_parameters.merge!(instance_app)
 
+      # Inject default app flag into parameters
+      app_parameters[:is_default_app] = is_default_app
+
       # App specific configuration, we can have many apps on one tomcat instance
       # Artifact setup
       imos_tomcat_webapp app_name do
         application_name     app_name
+        is_default_app       is_default_app
         artifact_name        artifact
         jndis                jndis
         backup               backup

--- a/cookbooks/imos_webapps/templates/default/portal/Portal.groovy.erb
+++ b/cookbooks/imos_webapps/templates/default/portal/Portal.groovy.erb
@@ -1,4 +1,4 @@
-grails.serverURL = "<%= @custom_parameters['https'] ? 'https' : 'http' %>://<%= @custom_parameters['vhost'] %>/<%= @custom_parameters['name'] %>"
+grails.serverURL = "<%= @custom_parameters['https'] ? 'https' : 'http' %>://<%= @custom_parameters['vhost'] %>/<%= @custom_parameters['is_default_app'] == 'true' ? '' : @custom_parameters['name'] %>"
 spatialsearch.url = "<%= @custom_parameters['spatialsearch_url'] || 'http://search-123.aodn.org.au/search/search/index' %>"
 wmsScanner.url = "<%= @custom_parameters['wms_scanner_url'] || 'http://wmsscanner.aodn.org.au/wmsscanner/' %>"
 wfsScanner.url = "<%= @custom_parameters['wfs_scanner_url'] || 'http://wfsscanner.aodn.org.au/wfsscanner/' %>"
@@ -116,7 +116,7 @@ portal {
 
         // URL to serve your site CSS from, this does not have to be from within
         // portal's context e.g. http://me.example.com/static/css/portal.css
-        css = "/<%= @custom_parameters['name'] %>/css/<%= @custom_parameters['css_name'] || @custom_parameters['name'].upcase %>.css"
+        css = "<%= @custom_parameters['is_default_app'] == 'true' ? '' : "/#{@custom_parameters['name']}" %>/css/<%= @custom_parameters['css_name'] || @custom_parameters['name'].upcase %>.css"
     }
 
     header {


### PR DESCRIPTION
* replace several instances of "Hash.first" with named indices
* add "default_app" attribute to Tomcat instance config item, and use this to inject an "is_default_app" flag into each app config item to allow it to set it's configuration accordingly. This enforces that only one app per instance may be assigned as default
* For default app deployment, deploy to ROOT Tomcat context (i.e. deploy as ROOT.war)