### PR TITLE
Add tablespace creation definition, and add to Postgres recipe

### DIFF
--- a/cookbooks/imos_postgresql/definitions/imos_postgresql_tablespace.rb
+++ b/cookbooks/imos_postgresql/definitions/imos_postgresql_tablespace.rb
@@ -1,0 +1,49 @@
+#
+# Cookbook Name:: imos_postgresql
+# Recipe:: official_postgres
+#
+# Copyright 2016, IMOS
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0c
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+define :imos_postgresql_tablespace, :cluster => "", :port => nil, :tablespace_name => nil, :directory => nil do
+
+  cluster_name = params[:cluster]
+  port = params[:port]
+
+  tablespace_name = params[:tablespace_name] or
+    Chef::Application.fatal!("Required parameter 'tablespace_name' missing")
+
+  directory = params[:directory] or
+    Chef::Application.fatal!("Required parameter 'directory' missing")
+
+  # Create tablespace
+  imos_postgresql_general "#{cluster_name}-#{tablespace_name}-tablespace" do
+    port      port
+    database  "postgres"
+    sql       <<-EOS
+      create tablespace #{tablespace_name} location '#{directory}';
+    EOS
+    Chef::Log.info("Creating tablespace '#{tablespace_name}' in directory '#{directory}'")
+    not_if {
+      PostgresqlHelper.query_boolean(port, "postgres",
+        <<-EOS
+          select exists (select spcname from pg_catalog.pg_tablespace where spcname = '#{tablespace_name}');
+        EOS
+      )}
+  end
+
+end
+

--- a/cookbooks/imos_postgresql/recipes/official_postgresql.rb
+++ b/cookbooks/imos_postgresql/recipes/official_postgresql.rb
@@ -271,6 +271,18 @@ if node['postgresql'] && node['postgresql']['clusters']
       end
     end
 
+    # Create tablespaces
+    Chef::Log.debug("All tablespaces: #{cluster['tablespaces']}")
+    cluster['tablespaces'].each do |tablespace|
+      Chef::Log.info("Processing tablespace: #{tablespace}")
+      imos_postgresql_tablespace tablespace['name'] do
+        cluster           cluster_name
+        port              cluster_config['port']
+        tablespace_name   tablespace['tablespace_name']
+        directory         tablespace['directory']
+      end
+    end if cluster['tablespaces']
+
     # Create databases
     modified_databases = PostgresqlHelper.modified_databases(cluster_name, all_databases)
     deleted_databases = PostgresqlHelper.deleted_databases(cluster_name, all_databases)


### PR DESCRIPTION
Reads "tablespaces" list from data bag, creates them if they don't exist. This allows the postgresql.conf file to use one or more of the defined tablespaces in the "temp_tablespaces" configuration item.

See private node configuration file for node configuration to enable this. Note that this method makes the same assumption as the main Postgres data directory, which is that the underlying volume *already exists* and the filesystem has been created (i.e with mkfs) and is available at the device node named in the 'mounts' array. This does means that it will not work in one step on a "from scratch" install outside of vagrant, however I believe this is the status quo anyway.