### PR TITLE
Revert "Add JQ to data_services recipe"

### DIFF
--- a/cookbooks/imos_po/attributes/data_services.rb
+++ b/cookbooks/imos_po/attributes/data_services.rb
@@ -54,7 +54,6 @@ default['imos_po']['data_services']['packages'] = [
   'imagemagick',
   'ipython',
   'gawk',
-  'jq',
   'lftp',
   'libhdf5-serial-dev',
   'libnetcdf-dev',


### PR DESCRIPTION
Reverts aodn/chef#329

This fails on actual servers because precise-backports is enabled in Vagrant but not on live servers. This resulted in testing succeeding, but deployment broke things.