### PR TITLE
Update PO box compliance checker version

### DIFF
--- a/cookbooks/imos_po/attributes/netcdf_checker.rb
+++ b/cookbooks/imos_po/attributes/netcdf_checker.rb
@@ -1,6 +1,4 @@
 default['imos_po']['netcdf_checker']['dir']           = "/usr/local/bin"
-default['imos_po']['netcdf_checker']['repo']          = "https://github.com/ioos/compliance-checker.git"
-default['imos_po']['netcdf_checker']['branch']        = "master"
 default['imos_po']['netcdf_checker']['executable']    = "/usr/local/bin/netcdf-checker"
 default['imos_po']['netcdf_checker']['version'] = '2.2.0'
 default['imos_po']['netcdf_checker']['url'] = "https://ci.aodn.org.au/job/compliance_checker/lastSuccessfulBuild/artifact/dist/compliance_checker-#{default['imos_po']['netcdf_checker']['version']}-py2.7.egg"

--- a/private-sample/nodes/po.json
+++ b/private-sample/nodes/po.json
@@ -58,10 +58,6 @@
         }
     },
     "imos_po": {
-        "netcdf_checker": {
-            "repo": "https://github.com/aodn/compliance-checker.git",
-            "branch": "IMOS-Checker"
-        },
         "data_services": {
             "create_watched_directories": true,
             "user": "vagrant",


### PR DESCRIPTION
@mhidas @ggalibert @lbesnard this updates the version on a fresh po box, you potentially need to uninstall the old plugin and compliance checker if updating an existing box.