### PR TITLE
Add 'postbuildscript' plugin to Jenkins

### DIFF
--- a/cookbooks/imos_jenkins/attributes/plugins.rb
+++ b/cookbooks/imos_jenkins/attributes/plugins.rb
@@ -10,6 +10,7 @@ default["imos_jenkins"]["plugins"] = %w{
   greenballs
   job-log-logger-plugin
   maven-plugin
+  postbuildscript
   repository
   role-strategy
   s3


### PR DESCRIPTION
Required to trigger S3 'symlink' redirection for latest artifact links