### PR TITLE
Handle "-m <mimetype>" argument to make mocked s3cmd not break due to…

### DIFF
--- a/cookbooks/imos_core/files/default/s3cmd
+++ b/cookbooks/imos_core/files/default/s3cmd
@@ -11,7 +11,9 @@ bucket_uri_to_file_path() {
 main() {
     local cmd src dst
     while [ x"$1" != x ]; do
-        if [ "${1:0:1}" = "-" ]; then
+        if [ "$1" = "-m" ]; then
+            shift
+        elif [ "${1:0:1}" = "-" ]; then
             true
         elif [ x"$cmd" = x ]; then
             cmd=$1


### PR DESCRIPTION
… https://github.com/aodn/data-services/commit/184f26679ff92ae8c05c0f01b1b226e164f51e88