### PR TITLE
Move compliance checker recipe from node_common to slave, since Jenki…

### DIFF
--- a/cookbooks/imos_jenkins/recipes/node_common.rb
+++ b/cookbooks/imos_jenkins/recipes/node_common.rb
@@ -23,7 +23,6 @@ include_recipe "imos_devel::talend"
 include_recipe "imos_devel::vagrant"
 include_recipe "imos_jenkins::packages"
 include_recipe "imos_po::packages"
-include_recipe "imos_po::netcdf_checker"
 
 include_recipe "imos_postgresql::official_postgresql"
 include_recipe "git"

--- a/cookbooks/imos_jenkins/recipes/slave.rb
+++ b/cookbooks/imos_jenkins/recipes/slave.rb
@@ -10,6 +10,7 @@
 #
 
 include_recipe 'imos_jenkins::node_common'
+include_recipe 'imos_po::netcdf_checker'
 
 package "daemon"
 gem_package "trollop"


### PR DESCRIPTION
…ns master can't provision from itself while its cooking