### PR TITLE
Update celery command and configuration due to noisy deprecation warn…

### DIFF
--- a/cookbooks/imos_po/recipes/watches.rb
+++ b/cookbooks/imos_po/recipes/watches.rb
@@ -159,7 +159,7 @@ if node['imos_po']['data_services']['watches']
 
   async_upload_max_tasks = node['imos_po']['data_services']['async_upload']['max_tasks']
   supervisor_service "async_upload_po" do
-    command    "celeryd --queues=async_upload --config=#{celery_config} -A tasks -c #{async_upload_max_tasks}"
+    command "celery worker --queues=async_upload --config=#{celery_config} -A tasks -c #{async_upload_max_tasks}"
     directory  node['imos_po']['data_services']['celeryd']['dir']
     user       po_user
     action     [:enable, :restart]
@@ -174,7 +174,7 @@ if node['imos_po']['data_services']['watches']
       Chef::Recipe::WatchJobs.get_watches(data_services_watch_dir).each do |job_name, watchlist|
         f = Chef::Resource::SupervisorService.new("celery_po_#{job_name}", run_context)
         f.autostart true
-        f.command "celeryd --queues=#{job_name} --config=#{celery_config} -A tasks -c #{node['imos_po']['data_services']['celeryd']['max_tasks']}"
+        f.command "celery worker --queues=#{job_name} --config=#{celery_config} -A tasks -c #{node['imos_po']['data_services']['celeryd']['max_tasks']}"
         f.directory node['imos_po']['data_services']['celeryd']['dir']
         f.user po_user
         f.run_action :enable

--- a/cookbooks/imos_po/templates/default/celeryconfig.py.erb
+++ b/cookbooks/imos_po/templates/default/celeryconfig.py.erb
@@ -18,6 +18,8 @@ BROKER_TRANSPORT_OPTIONS = {
 <% end %>
 }
 
+CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']
+
 <%
 # Create automatic routing for all queues, kindly stolen from:
 # http://stackoverflow.com/questions/9167663/celery-per-task-concurrency-limits-of-workers-per-task


### PR DESCRIPTION
…ings in the supervisord logs

In each case,  the suggested change from the deprecation warnings has been made:

```
("\nThe 'celeryd' command is deprecated, please use 'celery worker' instead:\n\n$ celery worker --queues=ANFOG_RT --config=/mnt/ebs/data-services/celeryd/celeryconfig.py -A tasks -c 1\n\n",)
```
```
[2016-07-07 17:07:03,905: WARNING/MainProcess] /usr/local/lib/python2.7/dist-packages/celery/apps/worker.py:161: CDeprecationWarning:
Starting from version 3.2 Celery will refuse to accept pickle by default.

The pickle serializer is a security concern as it may give attackers
the ability to execute any command.  It's important to secure
your broker from unauthorized access when using pickle, so we think
that enabling pickle should require a deliberate action and not be
the default choice.

If you depend on pickle then you should set a setting to disable this
warning and to be sure that everything will continue working
when you upgrade to Celery 3.2::

    CELERY_ACCEPT_CONTENT = ['pickle', 'json', 'msgpack', 'yaml']

You must only enable the serializers that you will actually use.
```
