### PR TITLE
Move location of async_upload log to be accessible to POs

### DIFF
--- a/cookbooks/imos_po/recipes/watches.rb
+++ b/cookbooks/imos_po/recipes/watches.rb
@@ -162,6 +162,8 @@ if node['imos_po']['data_services']['watches']
     command "celery worker --queues=async_upload --config=#{celery_config} -A tasks -c #{async_upload_max_tasks}"
     directory  node['imos_po']['data_services']['celeryd']['dir']
     user       po_user
+    stdout_logfile ::File.join(node['imos_po']['data_services']['log_dir'], 'async_upload.log')
+    redirect_stderr true
     action     [:enable, :restart]
     subscribes :restart, 'git[data_services]', :delayed
   end


### PR DESCRIPTION
Since this queue is as the result of an interactive command executed by POs, it makes sense that this log is available to them to verify the success/failure of their file uploads. 

Due to a supervisord bug, when using the default "AUTO" location for log files, these are created with root-only access, so explicitly defining the path is required for permissions reasons. In addition, it makes sense that the log is in the data services log dir, as it is more intuitive for POs to find it there with the other logs than in /var/log/supervisor.