### PR TITLE
Fix error introduced when using a local artifact path

### DIFF
--- a/cookbooks/imos_artifacts/libraries/fetcher.rb
+++ b/cookbooks/imos_artifacts/libraries/fetcher.rb
@@ -45,7 +45,7 @@ module ImosArtifacts
           end
         end
       else
-        Chef::Log.warn("Could not obtain md5 via md5 file at '#{artifact_md5_url}'")
+        Chef::Log.warn("Could not obtain md5 via md5 file at '#{remote_md5_file}'")
       end
       tmpfile.unlink
 
@@ -53,6 +53,7 @@ module ImosArtifacts
       if not remote_checksum.nil? and File.exists?(filename)
         local_checksum = Digest::MD5.file(filename).hexdigest
         if remote_checksum == local_checksum
+          Chef::Log.info "Using cached artifact #{filename}'"
           return filename
         end
       end
@@ -65,7 +66,8 @@ module ImosArtifacts
         begin
           IO.copy_stream(Fetcher.get_uri_retry(uri, username, password), output)
         rescue
-          Chef::Application.fatal!("Error downloading file from '#{uri}'")
+          Chef::Log.error "Error downloading file from '#{uri}'"
+          return nil
         end
 
         Chef::Log.info "Cached '#{uri}' at '#{filename}'"
@@ -98,7 +100,8 @@ module ImosArtifacts
         Chef::Log.warn "Retrying #{i}/#{retries} '#{uri}'"
         sleep 2
       end
-      Chef::Application.fatal! "Could not access '#{uri}'"
+      Chef::Log.error "Could not access '#{uri}'"
+      return nil
     end
 
   end


### PR DESCRIPTION
@jonescc will resolve https://github.com/aodn/chef/issues/370

The summary of the change is that the Fetcher.download (and related) methods should not be exit points for the Chef run, and should instead return false if they fail, since the calling code uses the "if Fetcher.download then etc.." pattern in order to determine success anyway.