### PR TITLE
Allow filtering on point of truth and category

### DIFF
--- a/cookbooks/imos_webapps/templates/default/geonetwork/config-overrides.xml.erb
+++ b/cookbooks/imos_webapps/templates/default/geonetwork/config-overrides.xml.erb
@@ -158,4 +158,13 @@ if @custom_parameters['term_vocabulary']
 end
 %>
 
+    <!-- add additional csw search filters -->
+
+    <file name=".*WEB-INF/config-csw\.xml">
+        <addXml xpath="operations/operation[@name='GetRecords']/parameters">
+            <parameter name="PointOfTruth" field="pointOfTruth" type="AdditionalQueryables" />
+            <parameter name="Category" field="_cat" type="AdditionalQueryables" />
+        </addXml>
+    </file>
+
 </overrides>


### PR DESCRIPTION
Requires https://github.com/aodn/schema-plugins/pull/36 and https://github.com/aodn/core-geonetwork/pull/66 and updating the schema-plugins used by geonetwork to actually do anything.