### PR TITLE
Update S3FS build commands

### DIFF
--- a/cookbooks/s3fs-fuse/recipes/install.rb
+++ b/cookbooks/s3fs-fuse/recipes/install.rb
@@ -59,8 +59,9 @@ bash "compile_and_install_s3fs" do
   cwd '/tmp'
   code <<-EOH
     tar -xzf s3fs-#{s3fs_version}.tar.gz
-    cd s3fs-#{s3fs_version}
+    cd s3fs-fuse-#{s3fs_version}
     #{'export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/usr/lib64/pkgconfig' if node.platform_family == 'rhel'}
+    ./autogen.sh
     ./configure --prefix=/usr/local
     make && make install
   EOH


### PR DESCRIPTION
The build instructions have also changed with the move to Github.

Updated in line with: https://github.com/s3fs-fuse/s3fs-fuse

@mhidas maybe try this branch?