### PR TITLE
Process lock celery worker tasks, prevent restart of running process …

### DIFF
--- a/cookbooks/imos_po/recipes/watches.rb
+++ b/cookbooks/imos_po/recipes/watches.rb
@@ -174,16 +174,17 @@ if node['imos_po']['data_services']['watches']
   ruby_block "celery_po_supervisor" do
     block do
       Chef::Recipe::WatchJobs.get_watches(data_services_watch_dir).each do |job_name, watchlist|
+        pidfile = ::File.join(node['imos_po']['data_services']['log_dir'], "#{job_name}.pid")
         f = Chef::Resource::SupervisorService.new("celery_po_#{job_name}", run_context)
         f.autostart true
-        f.command "celery worker --queues=#{job_name} --config=#{celery_config} -A tasks -c #{node['imos_po']['data_services']['celeryd']['max_tasks']}"
+        f.command "celery worker --queues=#{job_name} --config=#{celery_config} --pidfile=#{pidfile}  -A tasks -c #{node['imos_po']['data_services']['celeryd']['max_tasks']}"
         f.directory node['imos_po']['data_services']['celeryd']['dir']
         f.user po_user
         f.run_action :enable
-        f.run_action :restart
+        f.run_action :start
       end
     end
-    subscribes :create, 'git[data_services]',     :delayed
+    subscribes :create, 'git[data_services]',         :delayed
     subscribes :create, 'python_package[supervisor]', :delayed
   end
 

--- a/cookbooks/imos_po/templates/default/tasks.py.erb
+++ b/cookbooks/imos_po/templates/default/tasks.py.erb
@@ -28,7 +28,7 @@ watchlists.each do |job_name, watchlist|
     execute = ::File.join(@data_services_dir, watchlist['execute'])
     execute_params = watchlist['execute_params']
 %>
-@app.task(ignore_result=True)
+@app.task
 def <%= job_name %>(file_path):
     watch_exec_wrapper("<%= job_name %>", file_path, "<%= execute %>", "<%= execute_params %>")
 


### PR DESCRIPTION
…due to DS SCM change

Retain state of running worker processes for loggin/debugging