### PR TITLE
prevent supervisord issuing sigkill leading to orphaned celery processes #431

### DIFF
--- a/cookbooks/imos_po/recipes/watches.rb
+++ b/cookbooks/imos_po/recipes/watches.rb
@@ -182,6 +182,8 @@ if node['imos_po']['data_services']['watches']
         f = Chef::Resource::SupervisorService.new("celery_po_#{job_name}", run_context)
         f.autostart true
         f.command "celery worker --queues=#{job_name} --config=#{celery_config} --pidfile=#{pidfile}  -A tasks -c #{node['imos_po']['data_services']['celeryd']['max_tasks']}"
+        # ie. one year. to avoid sigkill which will orphan child processes
+        f.stopwaitsecs 31536000
         f.directory node['imos_po']['data_services']['celeryd']['dir']
         f.stdout_logfile ::File.join(supervisor_child_logdir, "#{job_name}-stdout.log")
         f.stdout_logfile_maxbytes node['imos_po']['data_services']['supervisor']['stdout_logfile_maxbytes']


### PR DESCRIPTION
https://github.com/aodn/backlog/issues/431

I've tested this, by checking that chef writes the jobs files to /etc/supervisor.d correctly.

And by manually installing supervisord and configuring the following test job. 

After using supervisorctl to stop the job, supervisord sends it a SIGTERM signal, but never follows up with a SIGKILL due to the increase to the stopwaitsecs timeout. 

Instead, the job exits cleanly after terminating.

```
root@systest:/home/jfca# cat mytrap.sh 
#!/bin/bash

function sigterm {
  # Your cleanup code here
  echo 'got SIGTERM'
}

function sigkill {
  # Your cleanup code here
  echo 'got SIGQUIT'
}

trap sigterm SIGTERM
trap sigkill SIGQUIT 


echo "this process id: $$"

while :
 do
   sleep 1
   count=$(expr $count + 1)
   if [ "$count" -gt 60 ]; then
        echo 'terminating gracefully'
        exit 0
   fi
   echo $count
 done
```
 

