### PR TITLE
Fix permissions on first creation of GN data dir

### DIFF
--- a/cookbooks/imos_webapps/definitions/geonetwork.rb
+++ b/cookbooks/imos_webapps/definitions/geonetwork.rb
@@ -96,8 +96,12 @@ define :geonetwork do
     end
   end
 
-  Chef::Log.info("Set ownership of '#{data_dir}' to '#{node['tomcat']['user']}:#{node['tomcat']['user']}'")
-  FileUtils.chown_R node['tomcat']['user'], node['tomcat']['user'], data_dir
+  ruby_block "set permissions for #{app_name} data dir #{data_dir}" do
+    block do
+      require 'fileutils'
+      FileUtils.chown_R node['tomcat']['user'], node['tomcat']['user'], data_dir
+    end
+  end
 
   # log4j override file
   log4j_override_file = File.join(config_dir, "log4j-overrides.cfg")


### PR DESCRIPTION
I hate having to add another ruby block, but it's the only was I can see to deal with the recursive permissions
Chef directory block doesn't handle recursive permissions properly (bug or feature)