### PR TITLE
Add capability to add Tomcat instance-specific environment variables

### DIFF
--- a/cookbooks/tomcat/templates/default/setenv.sh.erb
+++ b/cookbooks/tomcat/templates/default/setenv.sh.erb
@@ -1,0 +1,4 @@
+<% @vars.each do |key, value| %>
+<% next if value.nil? -%>
+export <%= key %>=<%= value %>
+<% end %>


### PR DESCRIPTION
@jonescc the tomcat init script looks for this /etc/default/tomcat/$NAME file for inclusion if it exists, so would be interested to see how this works... keeps the variables off the general environment and also the tomcat command line... need to verify that the application can pick them up ok still.