### PR TITLE
Revert pip requirements install to a loop, due to dependency ordering…

### DIFF
--- a/cookbooks/imos_po/recipes/data_services.rb
+++ b/cookbooks/imos_po/recipes/data_services.rb
@@ -48,7 +48,11 @@ if node['imos_po']['data_services']['clone_repository']
   end
 end
 
-pip_requirements ::File.join(data_services_dir, "requirements.txt")
+python_requirements = ::File.join(data_services_dir, "requirements.txt")
+execute "python_requirements" do
+  command    "cat #{python_requirements} | xargs -n 1 -L 1 pip install"
+  subscribes :run, 'git[data_services]', :delayed
+end
 
 node['imos_po']['data_services']['owned_dirs'].each do |dir|
   directory dir do


### PR DESCRIPTION
… issues

This doesn't generally cause issues for already installed servers, but did cause dependency ordering issues when provisioning from scratch. Basically reverts https://github.com/aodn/chef/commit/365f57dd534a14c52677debb54c907db8774f1d7#diff-8f6d6e04921ff700779fb35dc2e70739R51