### PR TITLE
Revert change to remove 'ignore_result=True' from celery tasks

### DIFF
--- a/cookbooks/imos_po/templates/default/tasks.py.erb
+++ b/cookbooks/imos_po/templates/default/tasks.py.erb
@@ -28,7 +28,7 @@ watchlists.each do |job_name, watchlist|
     execute = ::File.join(@data_services_dir, watchlist['execute'])
     execute_params = watchlist['execute_params']
 %>
-@app.task
+@app.task(ignore_result=True)
 def <%= job_name %>(file_path):
     watch_exec_wrapper("<%= job_name %>", file_path, "<%= execute %>", "<%= execute_params %>")
 


### PR DESCRIPTION
This change has not been used, and I have a strong suspicion it is causing the load issues on 14-nec-hob. Partially reverts https://github.com/aodn/chef/pull/391

http://stackoverflow.com/questions/25162484/rabbitmq-beam-smp-and-high-cpu-memory-load-issue
http://stackoverflow.com/questions/6362829/rabbitmq-on-ec2-consuming-tons-of-cpu
http://docs.celeryproject.org/en/latest/userguide/tasks.html#tips-and-best-practices