### PR TITLE
Cause an 'apt-get update' before processing recipes. Fixes scenario w…

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -229,6 +229,7 @@ GRAPH
     imos_users (>= 0.0.0)
     logrotate (>= 0.0.0)
   imos_chef_solo (0.1.0)
+    apt (>= 0.0.0)
     chef-solo-search (>= 0.0.0)
   imos_core (0.1.0)
     build-essential (>= 0.0.0)

--- a/cookbooks/imos_chef_solo/metadata.rb
+++ b/cookbooks/imos_chef_solo/metadata.rb
@@ -6,4 +6,5 @@ description      "chef-solo-search wrapper"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 
+depends 'apt'
 depends 'chef-solo-search'

--- a/cookbooks/imos_chef_solo/recipes/default.rb
+++ b/cookbooks/imos_chef_solo/recipes/default.rb
@@ -7,6 +7,8 @@
 # All rights reserved - Do Not Redistribute
 #
 
+include_recipe 'apt'
+
 # Include those recipes if running under chef-solo
 if Chef::Config[:solo]
   include_recipe "chef-solo-search"


### PR DESCRIPTION
…ith outdated index attempting download on non-existent packages from repo.