### PR TITLE
remove old abos db role and schema

### DIFF
--- a/private-sample/data_bags/postgresql_databases/harvest.json
+++ b/private-sample/data_bags/postgresql_databases/harvest.json
@@ -27,10 +27,6 @@
                     "type": "write"
                 },
                 {
-                    "role": "abos",
-                    "type": "write"
-                },
-                {
                     "role": "aodn_dart",
                     "type": "write"
                 },
@@ -368,20 +364,6 @@
         {
             "name": "aatams_sattag_qc_ctd",
             "owner": "aatams_sattag_qc_ctd",
-            "permissions": [
-                {
-                    "role": "harvest_read_group",
-                    "type": "read"
-                },
-                {
-                    "role": "harvest_write_group",
-                    "type": "write"
-                }
-            ]
-        },
-        {
-            "name": "abos",
-            "owner": "abos",
             "permissions": [
                 {
                     "role": "harvest_read_group",

--- a/private-sample/data_bags/postgresql_roles/db_po_main.json
+++ b/private-sample/data_bags/postgresql_roles/db_po_main.json
@@ -421,10 +421,6 @@
             "password": "aatams_sattag_nrt"
         },
         {
-            "name": "abos",
-            "password": "abos"
-        },
-        {
             "name": "abos_sots",
             "password": "abos_sots",
             "memberof": [


### PR DESCRIPTION
This is for the old reporting harvester, which never ran on the PO box anyway, as far as I know.