### PR TITLE
Add missing dependencies for Nokogiri as they must be fulfilled by an…

### DIFF
--- a/cookbooks/imos_core/recipes/xml_tools.rb
+++ b/cookbooks/imos_core/recipes/xml_tools.rb
@@ -11,7 +11,7 @@
 include_recipe "build-essential"
 
 # Those ar needed to compile nokogiri
-%w{libxml2-dev libxslt1-dev zlib1g-dev binutils-doc bison unzip gettext flex ncurses-dev}.each do |pkg|
+%w{build-essential libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev ruby-dev binutils-doc bison unzip gettext flex ncurses-dev}.each do |pkg|
   # Use this method to install packages immediately rather than after
   # `chef_gem` resources
   pkg_resource = package pkg do


### PR DESCRIPTION
Nokogiri will not build without these deps on a basic pipeline node. They must be fulfilled by an unrelated recipe in the current use cases, but should be explicit here as well to keep it self contained.