### PR TITLE
Add Nectar rc.local recipe with suggested readahead values.

### DIFF
--- a/cookbooks/imos_core/files/default/rc.local-nectar
+++ b/cookbooks/imos_core/files/default/rc.local-nectar
@@ -1,0 +1,22 @@
+#!/bin/sh -e
+#
+# WARNING THIS FILE IS CHEF MANAGED
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+# Set readahead value for local disks
+lsblk -dn | awk '{print $1}' | while read vol; do
+  echo 4096 > /sys/class/block/${vol}/queue/read_ahead_kb
+done
+
+exit 0
+

--- a/cookbooks/imos_core/recipes/nectar_rclocal.rb
+++ b/cookbooks/imos_core/recipes/nectar_rclocal.rb
@@ -1,0 +1,14 @@
+#
+# Cookbook Name:: imos_core
+# Recipe:: nectar_rclocal
+#
+# Copyright 2013, IMOS
+#
+# All rights reserved - Do Not Redistribute
+#
+
+cookbook_file '/etc/rc.local' do
+  source 'rc.local-nectar'
+  mode '0755'
+  only_if { node.run_list?('role[nectar]') }
+end


### PR DESCRIPTION
Add rc.local which Nectar nodes can/should include. Primarily for storage readahead values, but made generic in case of other requirements.

Readahead value is as advised by TPAC for the underlying storage.