### PR TITLE
Partial revert of recipe to prevent Ruby lib issue

### DIFF
--- a/cookbooks/imos_core/recipes/xml_tools.rb
+++ b/cookbooks/imos_core/recipes/xml_tools.rb
@@ -11,7 +11,7 @@
 include_recipe "build-essential"
 
 # Those ar needed to compile nokogiri
-%w{build-essential libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev ruby-dev binutils-doc bison unzip gettext flex ncurses-dev}.each do |pkg|
+%w{build-essential libxml2-dev libxslt1-dev zlib1g-dev liblzma-dev binutils-doc bison unzip gettext flex ncurses-dev}.each do |pkg|
   # Use this method to install packages immediately rather than after
   # `chef_gem` resources
   pkg_resource = package pkg do


### PR DESCRIPTION
This inadvertently installs Ruby 1.8 which causes problems with library paths, breaking some Ruby scripts which use the system interpreter (mostly those requiring trollop).