### PR TITLE
Revert "Change Ruby interpreter for check_nagios_monitors"

### DIFF
--- a/cookbooks/nagios/files/default/plugins/check_nagios_monitors
+++ b/cookbooks/nagios/files/default/plugins/check_nagios_monitors
@@ -1,4 +1,4 @@
-#!/opt/chef/embedded/bin/ruby
+#!/usr/bin/ruby
 
 require 'nokogiri'
 require 'open-uri'


### PR DESCRIPTION
Reverts aodn/chef#441

Not required due to proper fix: https://github.com/aodn/chef/pull/443