### PR TITLE
Point env.properties file to the correct AWS creds

### DIFF
--- a/cookbooks/imos_jenkins/attributes/default.rb
+++ b/cookbooks/imos_jenkins/attributes/default.rb
@@ -18,7 +18,7 @@ default['imos_jenkins']['s3cmd']['config_file'] = ::File.join(node['jenkins']['m
 
 default['imos_jenkins']['monitored_jobs'] = []
 
-default['imos_jenkins']['s3']['credentials_databag'] = 'aws'
+default['imos_jenkins']['s3']['credentials_databag'] = 'jenkins'
 default['imos_jenkins']['s3']['credentials_databag_dev'] = 'aws-dev'
 
 default['imos_jenkins']['node_common']['packages'] = [


### PR DESCRIPTION
Fixes thredds_systest deployment VIT @jonescc 