### PR TITLE
Package trollop gem on jenkins for chef specs

### DIFF
--- a/cookbooks/imos_jenkins/recipes/managed_master.rb
+++ b/cookbooks/imos_jenkins/recipes/managed_master.rb
@@ -31,6 +31,8 @@ scm_repo = node['imos_jenkins']['scm_repo']
 
 ssh_wrapper = File.join("#{jenkins_home}", '.ssh', 'wrappers', 'git_deploy_wrapper.sh')
 
+gem_package 'trollop'
+
 node['imos_jenkins']['plugins'].each do |plugin_id, version|
   jenkins_plugin plugin_id do
     version version


### PR DESCRIPTION
Required for running chef specs, suspected that this was installed manually on previous jenkins