### PR TITLE
Fixes #470

### DIFF
--- a/cookbooks/imos_jenkins/attributes/default.rb
+++ b/cookbooks/imos_jenkins/attributes/default.rb
@@ -2,7 +2,7 @@ default['imos_jenkins']['user']                  = 'jenkins'
 default['imos_jenkins']['group']                 = 'jenkins'
 default['imos_jenkins']['ajp_port']              = 49187
 default['imos_jenkins']['master_url']            = "https://jenkins.aodn.org.au/"
-default['imos_jenkins']['master']['jvm_options'] = '-Xmx2G -Dhudson.model.ParametersAction.keepUndefinedParameters=true'
+default['imos_jenkins']['master']['jvm_options'] = '-Xmx2G -Dhudson.model.ParametersAction.keepUndefinedParameters=true -Djenkins.install.runSetupWizard=false'
 default['imos_jenkins']['master']['ssh_port']    = 2222
 default['imos_jenkins']['master']['home']        = '/home/jenkins'
 default['imos_jenkins']['git']['clone_timeout'] = 20
@@ -28,8 +28,23 @@ default['imos_jenkins']['node_common']['packages'] = [
     'shunit2',
     'zip'
 ]
+# this is to fix an issue brought about by a change in Ruby versioning.
+# The issue will need to be fixed in the opscode jenkins cookbook. There's a bug logged.
+#TODO: Remove this when the issue has been fixed and we've updated to the fixed jenkins cookbook
+class Chef::Provider::JenkinsPlugin
+  alias old_plugin_version plugin_version
+  def plugin_version(version)
+    return version if version == "1.0-beta-1"
+
+    old_plugin_version(version)
+  end
+end
 
 default['imos_jenkins']['plugins'] = {
+    'mailer' => '	1.18',
+    'credentials' => '2.1.10',
+    'ssh-credentials' => '1.12',
+    'ssh-slaves' => '1.12',
     'build-name-setter' => '1.6.5',
     'build-pipeline-plugin' => '1.5.6',
     'copyartifact' => '1.38.1',
@@ -45,15 +60,17 @@ default['imos_jenkins']['plugins'] = {
     'maven-plugin' => '2.14',
     'role-strategy' => '2.3.2',
     's3' => '0.10.11',
-    'ssh-slaves' => '1.12',
     'throttle-concurrents' => '1.9.0',
     'xvfb' => '1.1.3',
     'token-macro' => '2.0',
     'ws-cleanup' => '0.32',
-    'validating-string-parameter' => '2.3'
+    'validating-string-parameter' => '2.3',
+
 }
 
 default['imos_jenkins']['node_common']['python_packages'] = [
   'awscli',
   'xmltodict'
 ]
+
+

--- a/cookbooks/imos_jenkins/recipes/managed_master.rb
+++ b/cookbooks/imos_jenkins/recipes/managed_master.rb
@@ -31,6 +31,24 @@ scm_repo = node['imos_jenkins']['scm_repo']
 
 ssh_wrapper = File.join("#{jenkins_home}", '.ssh', 'wrappers', 'git_deploy_wrapper.sh')
 
+# Overwrite local files with those present in SCM
+execute 'init_jenkins_scm' do
+  command "git rev-parse --is-inside-work-tree || { git init && git remote add origin #{scm_repo} && git fetch && git reset --hard origin/master; }"
+  cwd jenkins_home
+  user node['imos_jenkins']['user']
+  group node['imos_jenkins']['group']
+end
+
+require 'openssl'
+require 'net/ssh'
+
+jenkins_ssh_key = Chef::EncryptedDataBagItem.load("users", "chef")['ssh_private_key']
+key = OpenSSL::PKey::RSA.new(jenkins_ssh_key)
+private_key = key.to_pem
+
+public_key = "#{key.ssh_type} #{[key.to_blob].pack('m0')}"
+node.run_state[:jenkins_private_key] = private_key
+
 node['imos_jenkins']['plugins'].each do |plugin_id, version|
   jenkins_plugin plugin_id do
     version version
@@ -45,13 +63,7 @@ execute 'git_ssh' do
   notifies :run, "execute[init_jenkins_scm]", :immediately
 end
 
-# Overwrite local files with those present in SCM
-execute 'init_jenkins_scm' do
-  command "git rev-parse --is-inside-work-tree || { git init && git remote add origin #{scm_repo} && git fetch && git reset --hard origin/master; }"
-  cwd jenkins_home
-  user node['imos_jenkins']['user']
-  group node['imos_jenkins']['group']
-end
+
 
 # AWS passwords
 envvars = {}


### PR DESCRIPTION
NOTE: requires PR #472 to run successfully (or a fix of the incompatible checksum)

* Overwrite local config files with SCM files before installing plugins, since plugins can't be installed without an admin account
* add hacky fix for a bug in the version of the jenkins cookbook which we upgraded to in the chef-refresh

