### PR TITLE
Allow Postgres connections from IPv6 localhost address to enable backups

### DIFF
--- a/cookbooks/imos_postgresql/attributes/default.rb
+++ b/cookbooks/imos_postgresql/attributes/default.rb
@@ -25,6 +25,7 @@ default[:imos_postgresql][:config] = {
 default[:imos_postgresql][:hba] = [
   {:type => 'hostssl', :db => 'all', :user => 'postgres', :addr => '0.0.0.0/0', :method => 'reject' },
   {:type => 'local', :db => 'all', :user => 'postgres', :addr => nil, :method => 'peer'},
+  {:type => 'hostssl', :db => 'all', :user => 'all', :addr => '::1/128', :method => 'md5'},
   {:type => 'hostssl', :db => 'all', :user => 'all', :addr => '0.0.0.0/0', :method => 'md5'},
 ]
 


### PR DESCRIPTION
Ubuntu 16.04 attempts to connect to Postgres via "localhost" which now resolves to the IPv6 address by default.

This is causing the following error when attempting a pgsql backup on a 16.04 instance:
```bash
[Tuesday 21 March 05:03:44 UTC 2017] INFO: Executing module 'backup::imos_pgsql' with parameters <snip>
psql: FATAL:  no pg_hba.conf entry for host "::1", user "backup", database "geonetwork", SSL on
FATAL:  no pg_hba.conf entry for host "::1", user "backup", database "geonetwork", SSL off
[Tuesday 21 March 05:03:44 UTC 2017] FATAL: Failed to get schemas from database 'geonetwork'
```