### PR TITLE
Add netcdf-bin to imos_po::data_services recipe

### DIFF
--- a/cookbooks/imos_po/attributes/data_services.rb
+++ b/cookbooks/imos_po/attributes/data_services.rb
@@ -60,6 +60,7 @@ default['imos_po']['data_services']['packages'] = [
   'libnetcdf-dev',
   'libproj-dev', # For Python/GDAL
   'mdbtools',
+  'netcdf-bin',
   'p7zip',
   'python-beautifulsoup',
   'python-boto',


### PR DESCRIPTION
netcdcf-bin package was no longer being installed, due to tidy up in https://github.com/aodn/chef/pull/471

Adding to general data_services attributes instead of *_devel recipe, since it is fairly generic requirement for POs.