### PR TITLE
Add tracefs to the list of unchecked filesystems in Nagios (for Ubunt…

### DIFF
--- a/cookbooks/nagios/recipes/imos_client_system.rb
+++ b/cookbooks/nagios/recipes/imos_client_system.rb
@@ -20,7 +20,7 @@ nagios_nrpecheck "check_disks" do
   command "#{node['nagios']['plugin_dir']}/check_disk"
   warning_condition "8%"
   critical_condition "5%"
-  parameters "-A -x /dev/shm -X nfs -X fuse.sshfs -i /boot"
+  parameters "-A -x /dev/shm -X nfs -X fuse.sshfs -X tracefs -i /boot"
   action :add
 end
 


### PR DESCRIPTION
…u 16.04)

After debugging an issue on 1-nec-hob, it left a tracefs filesystem mounted (now unmounted). It broke the Nagios check_disk check, so adding it to exclusions as it is never relevant to check.