### PR TITLE
Update vagrant and virtualbox versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ This chef repository contains all cookbooks used for the IMOS infrastructure.
 |git  | | `apt-get` |
 |ruby | >= 1.9.3 | `apt-get` / [`rbenv`](https://github.com/sstephenson/rbenv) |
 |bundler |  | `gem` |
-|[vagrant](http://www.vagrantup.com) | >= 1.7.4 | Download package from website |
+|[vagrant](http://www.vagrantup.com) | >= 1.8.6 | Download package from website |
 |[chef_dk](http://downloads.getchef.com/chef-dk/)| >= 0.6.0 | Install for your own distribution |
 |[vagrant-berkshelf](https://github.com/berkshelf/vagrant-berkshelf) | >= 4.0.1 | `vagrant plugin install vagrant-berkshelf` |
-|[VirtualBox](https://www.virtualbox.org/wiki/Downloads) |  | `apt-get` |
+|[VirtualBox](https://www.virtualbox.org/wiki/Downloads) | >= 5.1.6 | Download package from website |
 
 *See websites or documentation for more detailed insallation instructions*
 


### PR DESCRIPTION
Newer versions required to work with 16.04 xenial basebox