### PR TITLE
Install grails 2.1.0 for jenkins

### DIFF
--- a/cookbooks/imos_jenkins/attributes/default.rb
+++ b/cookbooks/imos_jenkins/attributes/default.rb
@@ -88,7 +88,7 @@ default['imos_jenkins']['plugins'] = {
     'validating-string-parameter' => '2.3'
 }
 
-default['imos_jenkins']['managed_master']['grails_installations'] = %w(2.4.4 1.3.7)
+default['imos_jenkins']['managed_master']['grails_installations'] = %w(2.4.4 2.1.0 1.3.7)
 
 default['imos_jenkins']['node_common']['python_packages'] = %w(awscli xmltodict)
 

--- a/cookbooks/imos_jenkins/recipes/managed_master.rb
+++ b/cookbooks/imos_jenkins/recipes/managed_master.rb
@@ -56,7 +56,6 @@ node['imos_jenkins']['managed_master']['grails_installations'].each do |grails_v
     && sdk install grails #{grails_version}'
     EOH
     user jenkins_user
-    action :nothing
     subscribes :run, 'bash[install_sdkman]', :delayed
   end
 end


### PR DESCRIPTION
@akashisama also fixes an issue where new grails versions are not installed by default due to action :nothing on the install grails bash block. I have disabled this as the script itself exits installation if the version is already installed.