### PR TITLE
Configure squid in HTTP accelerator mode, in line with Squid docs

### DIFF
--- a/cookbooks/imos_squid/templates/default/imos-custom.conf.erb
+++ b/cookbooks/imos_squid/templates/default/imos-custom.conf.erb
@@ -8,3 +8,12 @@ strip_query_terms off
 refresh_pattern <%= refresh_pattern['regex'] %> <%= refresh_pattern['min'] || node['squid']['cache_min'] %> <%= refresh_pattern['percent'] || node['squid']['cache_percent'] %> <%= refresh_pattern['max'] || node['squid']['cache_max'] %> <%= refresh_pattern['extra_opts'] || node['squid']['extra_opts'] %>
 <% end %>
 
+# HTTP accelerator configuration
+acl our_sites dstdomain <% node['webapps']['instances'].each do |instance| %><%= instance['vhost'] %> <% end -%>
+http_access allow our_sites
+
+<% node['webapps']['instances'].each do |instance| %>
+cache_peer localhost parent <%= instance['port'] %> 0 no-query originserver name=<%= instance['vhost'] %>
+cache_peer_access <%= instance['vhost'] %> allow our_sites
+cache_peer_access <%= instance['vhost'] %> deny all
+<% end -%>

--- a/cookbooks/imos_squid/templates/default/squid.conf.erb
+++ b/cookbooks/imos_squid/templates/default/squid.conf.erb
@@ -35,6 +35,14 @@ acl Safe_ports port <%= port %>
 acl purge method PURGE
 acl CONNECT method CONNECT
 
+<% if node['squid']['port'].kind_of?(Array) %>
+  <% node['squid']['port'].each do |port| %>
+http_port <%= port %>
+  <% end %>
+<% else %>
+http_port <%= node['squid']['port'] %> accel allow-direct vhost
+<% end %>
+
 # Managed with Chef
 <% @host_acl.each do |host| %>
 acl <%= host[0] %> <%= host[1] %> <%= host[2] %>
@@ -58,13 +66,7 @@ http_access allow localhost
 
 <%= "icp_access allow localnet" if !@localnets.empty? %>
 <%= "icp_access deny all" if node['squid']['icp_access_deny_all'] %>
-<% if node['squid']['port'].kind_of?(Array) %>
-  <% node['squid']['port'].each do |port| %>
-http_port <%= port %>
-  <% end %>
-<% else %>
-http_port <%= node['squid']['port'] %>
-<% end %>
+
 
 <% node['squid']['logformats'].each do |name, format| %>
 logformat <%= name %> <%= format %>


### PR DESCRIPTION
Squid currently gets configured as a more or less generic forward proxy by the squid cookbook.

This attempts to configure it more in line with the following official doco as a *reverse* proxy, as documented here:

http://wiki.squid-cache.org/ConfigExamples/Reverse/VirtualHosting

May be a solution to https://github.com/aodn/issues/issues/64